### PR TITLE
fix: update aqua to v2.36.0 to resolve cosign TUF verification failure

### DIFF
--- a/.github/workflows/pr-build-check.yml
+++ b/.github/workflows/pr-build-check.yml
@@ -1,0 +1,21 @@
+name: PR build check
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'aqua.yaml'
+
+jobs:
+  build-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Build Docker image
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991
+        with:
+          context: .
+          push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 
 RUN apt update && apt install -y curl wget iputils-ping net-tools inetutils-traceroute postgresql-client redis-tools && apt clean && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://github.com/aquaproj/aqua/releases/download/v2.21.0/aqua_linux_amd64.tar.gz && \
+RUN wget https://github.com/aquaproj/aqua/releases/download/v2.36.0/aqua_linux_amd64.tar.gz && \
     tar -xvf aqua_linux_amd64.tar.gz && \
     mv aqua /usr/local/bin && \
     rm -rf aqua_linux_amd64.tar.gz


### PR DESCRIPTION
## Summary

- Update aqua from v2.21.0 to v2.36.0 in Dockerfile to fix cosign TUF root key verification failure
- aqua v2.21.0 bundles cosign v1.13.1 which is incompatible with the rotated Sigstore TUF root keys, causing `aqua i` to fail with `invalid key` error for kubernetes/kubectl
- Add PR build check workflow (`.github/workflows/pr-build-check.yml`) to validate Dockerfile/aqua.yaml changes before merge

## Background

The image build on `main` has been failing with:

```
package_name=kubernetes/kubectl  package_version=v1.32.1
Error: verifying blob: getting Fulcio roots: initializing tuf:
  updating local metadata and targets:
  error updating to TUF remote mirror: invalid key
```

This is unrelated to recent dependency PRs — it is caused by an external Sigstore TUF root key rotation.

## Test plan

- [ ] PR build check workflow runs and passes (docker build with `push: false`)
- [ ] After merge, `deploy_ghcr.yml` builds and pushes successfully on main